### PR TITLE
Used options to pass in size parameter inside the body of API call for msearch

### DIFF
--- a/lib/rom/elasticsearch/query_multiplexer.rb
+++ b/lib/rom/elasticsearch/query_multiplexer.rb
@@ -9,6 +9,7 @@ module ROM
 
       param :client
       option :relations, default: -> { [] }
+      option :size, default: -> { 10 }
       option :response, optional: true, reader: false
 
       def relations(new = nil)
@@ -20,8 +21,12 @@ module ROM
         end
       end
 
+      def set_size(size)
+        with(size: size)
+      end
+
       def body
-        relations.map {|r| [r.dataset.params, r.dataset.body] }.flatten
+        relations.map { |r| [r.dataset.params, r.dataset.body.merge({size: @size})] }.flatten
       end
 
       def to_a


### PR DESCRIPTION
Handled size parameter necessary for first and last limits to work, if not passed or set, this would now default to 10 which is equivalent to elasticsearch default right now.